### PR TITLE
v0.4.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # Node Config Types - Revision History
 
+- ????
+  - Change readme.md example to use proper import
+
 - 2021-10-26: v0.3.2
   - Updated example in readme
   - Added badge to readme

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,12 @@
 # Node Config Types - Revision History
 
-- ????
+- 2021-10-27: v0.4.0
   - Change readme.md example to use proper import
+  - Move mergeOptions into stand-alone method
+  - Deprecate BaseConfigurable.mergeOptions
+  - Add BaseEmittingConfigurable, BaseLoggingConfigurable, BaseLoggingEmittingConfigurable
+  - Removed hard requirement to extend IConfig
+  - Added default for type of config (IConfig) and the logger (ILogAdpater from @msamblanet/node-slf)
 
 - 2021-10-26: v0.3.2
   - Updated example in readme

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project provides a minimal implementation of types and base classes for con
 The sample below is provided in ```example-module.ts``` for use as a template for new components (if desired).
 
 ```typescript
-import { IConfig, Overrides, BaseConfigurable } from './src/index.js'; // '@msamblanet/node-config-types';
+import { IConfig, Overrides, BaseConfigurable } from '@msamblanet/node-config-types';
 
 type Logger = unknown; // Placeholder type for this example
 

--- a/README.md
+++ b/README.md
@@ -8,26 +8,33 @@ This project provides a minimal implementation of types and base classes for con
 
 The sample below is provided in ```example-module.ts``` for use as a template for new components (if desired).
 
-```typescript
-import { IConfig, Overrides, BaseConfigurable } from '@msamblanet/node-config-types';
+Variations of ```BaseConfigurable``` are provided to account for logging classes and event emitters.  The full list of base clases are:
 
-type Logger = unknown; // Placeholder type for this example
+- ```BaseConfigurable<C>```
+- ```BaseEmittingConfigurable<C>``` - Subclasses ```EventEmitter```
+- ```BaseLoggingConfigurable<C,L>``` - Exposes ```log``` in a protected member
+- ```BaseLoggingEmittingConfigurable<C,L>``` - Exposes ```log``` in a protected member, subclasses ```EventEmitter```
+- In all of the above:
+  - ```C``` is the type of the config and defaults to ```IConfig```
+  - ```L``` is the type of the logger and it defaults to ```ILogAdapter``` from ```@msamblanet/slf4j``` (but can be anything)
+
+```typescript
+import { IConfig, Overrides, mergeOptions, BaseLoggingConfigurable } from '@msamblanet/node-config-types';
+
+export type IExampleLogger = unknown;
 
 // ********************************************************
 
-export interface FooConfig extends IConfig {
+export interface FooConfig {
   a: number;
   b: number;
 }
 
-export class SimpleFoo extends BaseConfigurable<FooConfig> {
+export class SimpleFoo extends BaseLoggingConfigurable<FooConfig, IExampleLogger> {
   public static readonly DEFAULT_CONFIG = { a: 1, b: 2 };
 
-  protected readonly log: Logger;
-
-  public constructor(log: Logger, ...config: Overrides<FooConfig>) {
-    super(SimpleFoo.DEFAULT_CONFIG, ...config);
-    this.log = log;
+  public constructor(log: IExampleLogger, ...config: Overrides<FooConfig>) {
+    super(log, SimpleFoo.DEFAULT_CONFIG, ...config);
   }
 
   public someMethod(): number {
@@ -37,19 +44,16 @@ export class SimpleFoo extends BaseConfigurable<FooConfig> {
 
 // ********************************************************
 
-export interface AbstractFooConfig extends IConfig {
+export interface AbstractFooConfig {
   a: number;
   b: number;
 }
 
-export abstract class AbstractFoo<X extends AbstractFooConfig = AbstractFooConfig> extends BaseConfigurable<X> {
+export abstract class AbstractFoo<X extends AbstractFooConfig = AbstractFooConfig> extends BaseLoggingConfigurable<X, IExampleLogger> {
   public static readonly DEFAULT_CONFIG = { a: 1, b: 2 };
 
-  protected readonly log: Logger;
-
-  public constructor(log: Logger, defaults: X, ...config: Overrides<X>) {
-    super(defaults, ...config);
-    this.log = log;
+  public constructor(log: IExampleLogger, defaults: X, ...overrides: Overrides<X>) {
+    super(log, defaults, ...overrides);
   }
 
   public abstract someMethod(): number;
@@ -62,13 +66,13 @@ export interface ConcreteFooConfig extends AbstractFooConfig {
 }
 
 export class ConcreteFoo extends AbstractFoo<ConcreteFooConfig> {
-  public static readonly DEFAULT_CONFIG: ConcreteFooConfig = BaseConfigurable.mergeOptions(AbstractFoo.DEFAULT_CONFIG, {
+  public static readonly DEFAULT_CONFIG: ConcreteFooConfig = mergeOptions<ConcreteFooConfig>(AbstractFoo.DEFAULT_CONFIG, {
     b: 42,
     c: 3
   });
 
-  public constructor(log: Logger, ...config: Overrides<ConcreteFooConfig>) {
-    super(log, ConcreteFoo.DEFAULT_CONFIG, ...config);
+  public constructor(log: IExampleLogger, ...overrides: Overrides<ConcreteFooConfig>) {
+    super(log, ConcreteFoo.DEFAULT_CONFIG, ...overrides);
   }
 
   public someMethod(): number {

--- a/example.ts
+++ b/example.ts
@@ -1,22 +1,19 @@
-import { IConfig, Overrides, BaseConfigurable } from './src/index.js'; // '@msamblanet/node-config-types';
+import { Overrides, mergeOptions, BaseLoggingConfigurable } from './src/index.js'; // '@msamblanet/node-config-types';
 
-type Logger = unknown; // Placeholder type for this example
+export type IExampleLogger = unknown;
 
 // ********************************************************
 
-export interface FooConfig extends IConfig {
+export interface FooConfig {
   a: number;
   b: number;
 }
 
-export class SimpleFoo extends BaseConfigurable<FooConfig> {
+export class SimpleFoo extends BaseLoggingConfigurable<FooConfig, IExampleLogger> {
   public static readonly DEFAULT_CONFIG = { a: 1, b: 2 };
 
-  protected readonly log: Logger;
-
-  public constructor(log: Logger, ...config: Overrides<FooConfig>) {
-    super(SimpleFoo.DEFAULT_CONFIG, ...config);
-    this.log = log;
+  public constructor(log: IExampleLogger, ...config: Overrides<FooConfig>) {
+    super(log, SimpleFoo.DEFAULT_CONFIG, ...config);
   }
 
   public someMethod(): number {
@@ -26,19 +23,16 @@ export class SimpleFoo extends BaseConfigurable<FooConfig> {
 
 // ********************************************************
 
-export interface AbstractFooConfig extends IConfig {
+export interface AbstractFooConfig {
   a: number;
   b: number;
 }
 
-export abstract class AbstractFoo<X extends AbstractFooConfig = AbstractFooConfig> extends BaseConfigurable<X> {
+export abstract class AbstractFoo<X extends AbstractFooConfig = AbstractFooConfig> extends BaseLoggingConfigurable<X, IExampleLogger> {
   public static readonly DEFAULT_CONFIG = { a: 1, b: 2 };
 
-  protected readonly log: Logger;
-
-  public constructor(log: Logger, defaults: X, ...config: Overrides<X>) {
-    super(defaults, ...config);
-    this.log = log;
+  public constructor(log: IExampleLogger, defaults: X, ...overrides: Overrides<X>) {
+    super(log, defaults, ...overrides);
   }
 
   public abstract someMethod(): number;
@@ -51,18 +45,16 @@ export interface ConcreteFooConfig extends AbstractFooConfig {
 }
 
 export class ConcreteFoo extends AbstractFoo<ConcreteFooConfig> {
-  public static readonly DEFAULT_CONFIG: ConcreteFooConfig = BaseConfigurable.mergeOptions(AbstractFoo.DEFAULT_CONFIG, {
+  public static readonly DEFAULT_CONFIG: ConcreteFooConfig = mergeOptions<ConcreteFooConfig>(AbstractFoo.DEFAULT_CONFIG, {
     b: 42,
     c: 3
   });
 
-  public constructor(log: Logger, ...config: Overrides<ConcreteFooConfig>) {
-    super(log, ConcreteFoo.DEFAULT_CONFIG, ...config);
+  public constructor(log: IExampleLogger, ...overrides: Overrides<ConcreteFooConfig>) {
+    super(log, ConcreteFoo.DEFAULT_CONFIG, ...overrides);
   }
 
   public someMethod(): number {
     return this.config.a + this.config.b + this.config.c;
   }
 }
-
-// ********************************************************

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@msamblanet/node-config-types",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@msamblanet/node-config-types",
-            "version": "0.3.1",
+            "version": "0.3.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "extend": "^3.0.2"
@@ -14,10 +14,14 @@
             "devDependencies": {
                 "@msamblanet/node-project-template": "^0.7.0",
                 "@types/extend": "^3.0.1",
+                "jest-mock-extended": "^2.0.4",
                 "tsdef": "^0.0.14"
             },
             "engines": {
                 "node": ">=16.7.0"
+            },
+            "optionalDependencies": {
+                "@msamblanet/node-slf": "^0.1.2"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1366,6 +1370,24 @@
                 "applyProjectTemplate": "src/update.js"
             }
         },
+        "node_modules/@msamblanet/node-slf": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@msamblanet/node-slf/-/node-slf-0.1.2.tgz",
+            "integrity": "sha512-q6fcDqIpgpcTLkG2NxdZ1VIIAR4kRWzs5WYzSxAjAYBLGzcnm/XwHuhpebFsgkfdc7vP9iVL7YE9dCXrJX4aEw==",
+            "optional": true,
+            "dependencies": {
+                "extend": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=16.7.0"
+            },
+            "optionalDependencies": {
+                "debug": "^4.3.2",
+                "pino": "^7.0.5",
+                "roarr": "^7.0.7",
+                "tslog": "^3.2.2"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2287,7 +2309,7 @@
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -2544,6 +2566,15 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "dev": true
         },
+        "node_modules/atomic-sleep": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+            "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+            "optional": true,
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
         "node_modules/aws-sign2": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -2770,6 +2801,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/boolean": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.4.tgz",
+            "integrity": "sha512-3hx0kwU3uzG6ReQ3pnaFQPSktpBw6RHN3/ivDKEuU8g1XSfafowyvDnadjv1xp8IZqhtSukxlwv9bF6FhX8m0w==",
+            "optional": true
+        },
         "node_modules/boxen": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
@@ -2973,7 +3010,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/builtin-modules": {
             "version": "3.2.0",
@@ -3538,7 +3575,7 @@
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
             "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -3637,7 +3674,7 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
             "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3664,7 +3701,7 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "object-keys": "^1.0.12"
             },
@@ -3880,6 +3917,32 @@
             "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
             "dev": true
         },
+        "node_modules/duplexify": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+            "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+            "optional": true,
+            "dependencies": {
+                "end-of-stream": "^1.4.1",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1",
+                "stream-shift": "^1.0.0"
+            }
+        },
+        "node_modules/duplexify/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "optional": true,
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/ecc-jsbn": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -3928,7 +3991,7 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "once": "^1.4.0"
             }
@@ -5463,7 +5526,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/fast-diff": {
             "version": "1.2.0",
@@ -5491,7 +5554,22 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
+            "devOptional": true
+        },
+        "node_modules/fast-json-stringify": {
+            "version": "2.7.11",
+            "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.7.11.tgz",
+            "integrity": "sha512-J6rw31EvrT/PTZ4xi5Sf/NjYt5jF8tAPVzIi82qmfD4niAwBbHvUB99H6ipHWEaNQKXXpoyG7THBVsbVPo9prw==",
+            "optional": true,
+            "dependencies": {
+                "ajv": "^6.11.0",
+                "deepmerge": "^4.2.2",
+                "rfdc": "^1.2.0",
+                "string-similarity": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
@@ -5504,6 +5582,33 @@
             "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
             "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
             "dev": true
+        },
+        "node_modules/fast-printf": {
+            "version": "1.6.9",
+            "resolved": "https://registry.npmjs.org/fast-printf/-/fast-printf-1.6.9.tgz",
+            "integrity": "sha512-FChq8hbz65WMj4rstcQsFB0O7Cy++nmbNfLYnD9cYv2cRn8EG6k/MGn9kO/tjO66t09DLDugj3yL+V2o6Qftrg==",
+            "optional": true,
+            "dependencies": {
+                "boolean": "^3.1.4"
+            },
+            "engines": {
+                "node": ">=10.0"
+            }
+        },
+        "node_modules/fast-redact": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.2.tgz",
+            "integrity": "sha512-YN+CYfCVRVMUZOUPeinHNKgytM1wPI/C/UCLEi56EsY2dwwvI00kIJHJoI7pMVqGoMew8SMZ2SSfHKHULHXDsg==",
+            "optional": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/fastify-warning": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/fastify-warning/-/fastify-warning-0.2.0.tgz",
+            "integrity": "sha512-s1EQguBw/9qtc1p/WTY4eq9WMRIACkj+HTcOIK1in4MV5aFaQC9ZCIt0dJ7pr5bIf4lPpHvAtP2ywpTNgs7hqw==",
+            "optional": true
         },
         "node_modules/fastq": {
             "version": "1.13.0",
@@ -5734,7 +5839,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
             }
@@ -5908,6 +6013,21 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/globalthis": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.2.tgz",
+            "integrity": "sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==",
+            "optional": true,
+            "dependencies": {
+                "define-properties": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/globby": {
@@ -6298,7 +6418,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/ini": {
             "version": "1.3.8",
@@ -6453,6 +6573,12 @@
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
             "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
             "dev": true
+        },
+        "node_modules/is-circular": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
+            "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA==",
+            "optional": true
         },
         "node_modules/is-core-module": {
             "version": "2.8.0",
@@ -7874,6 +8000,19 @@
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
+        "node_modules/jest-mock-extended": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-2.0.4.tgz",
+            "integrity": "sha512-MgL3B3GjURQFjjPGqbCANydA5BFNPygv0mYp4Tjfxohh9MWwxxX8Eq2p6ncCt/Vt+RAnaLlDaI7gwrDRD7Pt9A==",
+            "dev": true,
+            "dependencies": {
+                "ts-essentials": "^7.0.3"
+            },
+            "peerDependencies": {
+                "jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0",
+                "typescript": "^3.0.0 || ^4.0.0"
+            }
+        },
         "node_modules/jest-pnp-resolver": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
@@ -8769,7 +8908,7 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -8781,7 +8920,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/json5": {
             "version": "2.2.0",
@@ -9511,7 +9650,7 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/multimap": {
             "version": "1.1.0",
@@ -10061,7 +10200,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
             "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -10101,11 +10240,17 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/on-exit-leak-free": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+            "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==",
+            "optional": true
+        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -10429,6 +10574,43 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/pino": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/pino/-/pino-7.0.5.tgz",
+            "integrity": "sha512-ePain4FiooTqiqg0eLQ/KBfRepKPZBggmF1caUrLX+Ku1erPAiIZL3p2lycM3UhorVYbFt4CuDFAHP/d80hCzg==",
+            "optional": true,
+            "dependencies": {
+                "fast-redact": "^3.0.0",
+                "fastify-warning": "^0.2.0",
+                "get-caller-file": "^2.0.5",
+                "json-stringify-safe": "^5.0.1",
+                "on-exit-leak-free": "^0.2.0",
+                "pino-abstract-transport": "v0.4.0",
+                "pino-std-serializers": "^4.0.0",
+                "quick-format-unescaped": "^4.0.3",
+                "sonic-boom": "^2.2.1",
+                "thread-stream": "^0.11.1"
+            },
+            "bin": {
+                "pino": "bin.js"
+            }
+        },
+        "node_modules/pino-abstract-transport": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.4.0.tgz",
+            "integrity": "sha512-Znl3f1ntZnDG+NpCyJyJDS+lkrlRSbgQBkV3eqNAvet/QHql6rhKLc4DuYRlwfc3fvV611O9NXPm5pbT9AJ50g==",
+            "optional": true,
+            "dependencies": {
+                "duplexify": "^4.1.2",
+                "split2": "^3.2.2"
+            }
+        },
+        "node_modules/pino-std-serializers": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+            "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==",
+            "optional": true
+        },
         "node_modules/pirates": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -10655,7 +10837,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=6"
             }
@@ -10709,6 +10891,12 @@
                     "url": "https://feross.org/support"
                 }
             ]
+        },
+        "node_modules/quick-format-unescaped": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+            "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+            "optional": true
         },
         "node_modules/quick-lru": {
             "version": "5.1.1",
@@ -11197,6 +11385,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/rfdc": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+            "optional": true
+        },
         "node_modules/rimraf": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -11210,6 +11404,24 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/roarr": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/roarr/-/roarr-7.1.0.tgz",
+            "integrity": "sha512-lOoTAyhVp8pYHBm4KMEbY0EJMX7ZiONY5/IcjJxoEKk06GCkrahnfWnHUZxD70fi4PdCded0LsmfRYtxsdy/AA==",
+            "optional": true,
+            "dependencies": {
+                "boolean": "^3.1.4",
+                "fast-json-stringify": "^2.7.10",
+                "fast-printf": "^1.6.9",
+                "globalthis": "^1.0.2",
+                "is-circular": "^1.0.2",
+                "json-stringify-safe": "^5.0.1",
+                "semver-compare": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=12.0"
             }
         },
         "node_modules/run-parallel": {
@@ -11239,7 +11451,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/safe-regex": {
             "version": "2.1.1",
@@ -11333,7 +11545,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
             "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/semver-diff": {
             "version": "3.1.1",
@@ -11531,6 +11743,15 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/sonic-boom": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.3.0.tgz",
+            "integrity": "sha512-lEPaw654/4/rCJHz/TNzV4GIthqCq4inO+O3aFhbdOvR1bE+2//sVkcS+xlqPdb8gdjQCEE0hE9BuvnVixbnWQ==",
+            "optional": true,
+            "dependencies": {
+                "atomic-sleep": "^1.0.0"
+            }
+        },
         "node_modules/sort-object-keys": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
@@ -11604,7 +11825,7 @@
             "version": "0.5.20",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
             "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -11614,7 +11835,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -11665,6 +11886,29 @@
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz",
             "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==",
             "dev": true
+        },
+        "node_modules/split2": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+            "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+            "optional": true,
+            "dependencies": {
+                "readable-stream": "^3.0.0"
+            }
+        },
+        "node_modules/split2/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "optional": true,
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
         },
         "node_modules/sprintf-js": {
             "version": "1.0.3",
@@ -11730,11 +11974,17 @@
                 "node": ">=8"
             }
         },
+        "node_modules/stream-shift": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+            "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+            "optional": true
+        },
         "node_modules/string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
@@ -11751,6 +12001,12 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/string-similarity": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
+            "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==",
+            "optional": true
         },
         "node_modules/string-width": {
             "version": "1.0.2",
@@ -12140,6 +12396,12 @@
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
             "dev": true
         },
+        "node_modules/thread-stream": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.11.1.tgz",
+            "integrity": "sha512-YbZEIo+JcScRekY1bl7O717RZGA/1eT7t4n9uyKf5Fu7TYpZKuml185bQdV3l2pgoq0wCobkQySWxdNEORkghg==",
+            "optional": true
+        },
         "node_modules/throat": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
@@ -12258,6 +12520,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ts-essentials": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
+            "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
+            "dev": true,
+            "peerDependencies": {
+                "typescript": ">=3.7.0"
             }
         },
         "node_modules/ts-jest": {
@@ -12394,6 +12665,18 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "dev": true
+        },
+        "node_modules/tslog": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/tslog/-/tslog-3.2.2.tgz",
+            "integrity": "sha512-8dwb1cYpj3/w/MZTrSkPrdlA44loUodGT8N6ULMojqV4YByVM7ynhvVs9JwcIYxhhHf4bz1C5O3NKIPehnGp/w==",
+            "optional": true,
+            "dependencies": {
+                "source-map-support": "^0.5.19"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
@@ -12642,7 +12925,7 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }
@@ -12663,7 +12946,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/uuid": {
             "version": "3.4.0",
@@ -13080,7 +13363,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/write-file-atomic": {
             "version": "3.0.3",
@@ -14451,6 +14734,19 @@
                 "xo": "^0.45.0"
             }
         },
+        "@msamblanet/node-slf": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@msamblanet/node-slf/-/node-slf-0.1.2.tgz",
+            "integrity": "sha512-q6fcDqIpgpcTLkG2NxdZ1VIIAR4kRWzs5WYzSxAjAYBLGzcnm/XwHuhpebFsgkfdc7vP9iVL7YE9dCXrJX4aEw==",
+            "optional": true,
+            "requires": {
+                "debug": "^4.3.2",
+                "extend": "^3.0.2",
+                "pino": "^7.0.5",
+                "roarr": "^7.0.7",
+                "tslog": "^3.2.2"
+            }
+        },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -15243,7 +15539,7 @@
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -15441,6 +15737,12 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "dev": true
         },
+        "atomic-sleep": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+            "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+            "optional": true
+        },
         "aws-sign2": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -15617,6 +15919,12 @@
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
             "dev": true
         },
+        "boolean": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.4.tgz",
+            "integrity": "sha512-3hx0kwU3uzG6ReQ3pnaFQPSktpBw6RHN3/ivDKEuU8g1XSfafowyvDnadjv1xp8IZqhtSukxlwv9bF6FhX8m0w==",
+            "optional": true
+        },
         "boxen": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
@@ -15767,7 +16075,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true
+            "devOptional": true
         },
         "builtin-modules": {
             "version": "3.2.0",
@@ -16216,7 +16524,7 @@
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
             "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "ms": "2.1.2"
             }
@@ -16288,7 +16596,7 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
             "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-            "dev": true
+            "devOptional": true
         },
         "defer-to-connect": {
             "version": "1.1.3",
@@ -16306,7 +16614,7 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "object-keys": "^1.0.12"
             }
@@ -16466,6 +16774,31 @@
             "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
             "dev": true
         },
+        "duplexify": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+            "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+            "optional": true,
+            "requires": {
+                "end-of-stream": "^1.4.1",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1",
+                "stream-shift": "^1.0.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "optional": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
         "ecc-jsbn": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -16508,7 +16841,7 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "once": "^1.4.0"
             }
@@ -17636,7 +17969,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true
+            "devOptional": true
         },
         "fast-diff": {
             "version": "1.2.0",
@@ -17661,7 +17994,19 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
+            "devOptional": true
+        },
+        "fast-json-stringify": {
+            "version": "2.7.11",
+            "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.7.11.tgz",
+            "integrity": "sha512-J6rw31EvrT/PTZ4xi5Sf/NjYt5jF8tAPVzIi82qmfD4niAwBbHvUB99H6ipHWEaNQKXXpoyG7THBVsbVPo9prw==",
+            "optional": true,
+            "requires": {
+                "ajv": "^6.11.0",
+                "deepmerge": "^4.2.2",
+                "rfdc": "^1.2.0",
+                "string-similarity": "^4.0.1"
+            }
         },
         "fast-levenshtein": {
             "version": "2.0.6",
@@ -17674,6 +18019,27 @@
             "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
             "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
             "dev": true
+        },
+        "fast-printf": {
+            "version": "1.6.9",
+            "resolved": "https://registry.npmjs.org/fast-printf/-/fast-printf-1.6.9.tgz",
+            "integrity": "sha512-FChq8hbz65WMj4rstcQsFB0O7Cy++nmbNfLYnD9cYv2cRn8EG6k/MGn9kO/tjO66t09DLDugj3yL+V2o6Qftrg==",
+            "optional": true,
+            "requires": {
+                "boolean": "^3.1.4"
+            }
+        },
+        "fast-redact": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.2.tgz",
+            "integrity": "sha512-YN+CYfCVRVMUZOUPeinHNKgytM1wPI/C/UCLEi56EsY2dwwvI00kIJHJoI7pMVqGoMew8SMZ2SSfHKHULHXDsg==",
+            "optional": true
+        },
+        "fastify-warning": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/fastify-warning/-/fastify-warning-0.2.0.tgz",
+            "integrity": "sha512-s1EQguBw/9qtc1p/WTY4eq9WMRIACkj+HTcOIK1in4MV5aFaQC9ZCIt0dJ7pr5bIf4lPpHvAtP2ywpTNgs7hqw==",
+            "optional": true
         },
         "fastq": {
             "version": "1.13.0",
@@ -17860,7 +18226,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true
+            "devOptional": true
         },
         "get-intrinsic": {
             "version": "1.1.1",
@@ -17980,6 +18346,15 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true
+        },
+        "globalthis": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.2.tgz",
+            "integrity": "sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==",
+            "optional": true,
+            "requires": {
+                "define-properties": "^1.1.3"
+            }
         },
         "globby": {
             "version": "11.0.4",
@@ -18273,7 +18648,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "devOptional": true
         },
         "ini": {
             "version": "1.3.8",
@@ -18394,6 +18769,12 @@
                     "dev": true
                 }
             }
+        },
+        "is-circular": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
+            "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA==",
+            "optional": true
         },
         "is-core-module": {
             "version": "2.8.0",
@@ -19439,6 +19820,15 @@
                 "@types/node": "*"
             }
         },
+        "jest-mock-extended": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-2.0.4.tgz",
+            "integrity": "sha512-MgL3B3GjURQFjjPGqbCANydA5BFNPygv0mYp4Tjfxohh9MWwxxX8Eq2p6ncCt/Vt+RAnaLlDaI7gwrDRD7Pt9A==",
+            "dev": true,
+            "requires": {
+                "ts-essentials": "^7.0.3"
+            }
+        },
         "jest-pnp-resolver": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
@@ -20128,7 +20518,7 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
+            "devOptional": true
         },
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -20140,7 +20530,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-            "dev": true
+            "devOptional": true
         },
         "json5": {
             "version": "2.2.0",
@@ -20707,7 +21097,7 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "devOptional": true
         },
         "multimap": {
             "version": "1.1.0",
@@ -21122,7 +21512,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
             "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-            "dev": true
+            "devOptional": true
         },
         "object.assign": {
             "version": "4.1.2",
@@ -21147,11 +21537,17 @@
                 "es-abstract": "^1.19.1"
             }
         },
+        "on-exit-leak-free": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+            "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==",
+            "optional": true
+        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -21384,6 +21780,40 @@
             "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
             "dev": true
         },
+        "pino": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/pino/-/pino-7.0.5.tgz",
+            "integrity": "sha512-ePain4FiooTqiqg0eLQ/KBfRepKPZBggmF1caUrLX+Ku1erPAiIZL3p2lycM3UhorVYbFt4CuDFAHP/d80hCzg==",
+            "optional": true,
+            "requires": {
+                "fast-redact": "^3.0.0",
+                "fastify-warning": "^0.2.0",
+                "get-caller-file": "^2.0.5",
+                "json-stringify-safe": "^5.0.1",
+                "on-exit-leak-free": "^0.2.0",
+                "pino-abstract-transport": "v0.4.0",
+                "pino-std-serializers": "^4.0.0",
+                "quick-format-unescaped": "^4.0.3",
+                "sonic-boom": "^2.2.1",
+                "thread-stream": "^0.11.1"
+            }
+        },
+        "pino-abstract-transport": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.4.0.tgz",
+            "integrity": "sha512-Znl3f1ntZnDG+NpCyJyJDS+lkrlRSbgQBkV3eqNAvet/QHql6rhKLc4DuYRlwfc3fvV611O9NXPm5pbT9AJ50g==",
+            "optional": true,
+            "requires": {
+                "duplexify": "^4.1.2",
+                "split2": "^3.2.2"
+            }
+        },
+        "pino-std-serializers": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+            "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==",
+            "optional": true
+        },
         "pirates": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -21554,7 +21984,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-            "dev": true
+            "devOptional": true
         },
         "pupa": {
             "version": "2.1.1",
@@ -21585,6 +22015,12 @@
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true
+        },
+        "quick-format-unescaped": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+            "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+            "optional": true
         },
         "quick-lru": {
             "version": "5.1.1",
@@ -21948,6 +22384,12 @@
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
             "dev": true
         },
+        "rfdc": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+            "optional": true
+        },
         "rimraf": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -21955,6 +22397,21 @@
             "dev": true,
             "requires": {
                 "glob": "^7.1.3"
+            }
+        },
+        "roarr": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/roarr/-/roarr-7.1.0.tgz",
+            "integrity": "sha512-lOoTAyhVp8pYHBm4KMEbY0EJMX7ZiONY5/IcjJxoEKk06GCkrahnfWnHUZxD70fi4PdCded0LsmfRYtxsdy/AA==",
+            "optional": true,
+            "requires": {
+                "boolean": "^3.1.4",
+                "fast-json-stringify": "^2.7.10",
+                "fast-printf": "^1.6.9",
+                "globalthis": "^1.0.2",
+                "is-circular": "^1.0.2",
+                "json-stringify-safe": "^5.0.1",
+                "semver-compare": "^1.0.0"
             }
         },
         "run-parallel": {
@@ -21970,7 +22427,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
+            "devOptional": true
         },
         "safe-regex": {
             "version": "2.1.1",
@@ -22039,7 +22496,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
             "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
-            "dev": true
+            "devOptional": true
         },
         "semver-diff": {
             "version": "3.1.1",
@@ -22194,6 +22651,15 @@
                 "socks": "^2.6.1"
             }
         },
+        "sonic-boom": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.3.0.tgz",
+            "integrity": "sha512-lEPaw654/4/rCJHz/TNzV4GIthqCq4inO+O3aFhbdOvR1bE+2//sVkcS+xlqPdb8gdjQCEE0hE9BuvnVixbnWQ==",
+            "optional": true,
+            "requires": {
+                "atomic-sleep": "^1.0.0"
+            }
+        },
         "sort-object-keys": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
@@ -22254,7 +22720,7 @@
             "version": "0.5.20",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
             "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -22264,7 +22730,7 @@
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
+                    "devOptional": true
                 }
             }
         },
@@ -22311,6 +22777,28 @@
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz",
             "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==",
             "dev": true
+        },
+        "split2": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+            "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+            "optional": true,
+            "requires": {
+                "readable-stream": "^3.0.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "optional": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
         },
         "sprintf-js": {
             "version": "1.0.3",
@@ -22361,11 +22849,17 @@
                 }
             }
         },
+        "stream-shift": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+            "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+            "optional": true
+        },
         "string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "safe-buffer": "~5.1.0"
             }
@@ -22379,6 +22873,12 @@
                 "char-regex": "^1.0.2",
                 "strip-ansi": "^6.0.0"
             }
+        },
+        "string-similarity": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
+            "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==",
+            "optional": true
         },
         "string-width": {
             "version": "1.0.2",
@@ -22666,6 +23166,12 @@
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
             "dev": true
         },
+        "thread-stream": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.11.1.tgz",
+            "integrity": "sha512-YbZEIo+JcScRekY1bl7O717RZGA/1eT7t4n9uyKf5Fu7TYpZKuml185bQdV3l2pgoq0wCobkQySWxdNEORkghg==",
+            "optional": true
+        },
         "throat": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
@@ -22755,6 +23261,13 @@
             "integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==",
             "dev": true
         },
+        "ts-essentials": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
+            "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
+            "dev": true,
+            "requires": {}
+        },
         "ts-jest": {
             "version": "27.0.7",
             "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.0.7.tgz",
@@ -22839,6 +23352,15 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "dev": true
+        },
+        "tslog": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/tslog/-/tslog-3.2.2.tgz",
+            "integrity": "sha512-8dwb1cYpj3/w/MZTrSkPrdlA44loUodGT8N6ULMojqV4YByVM7ynhvVs9JwcIYxhhHf4bz1C5O3NKIPehnGp/w==",
+            "optional": true,
+            "requires": {
+                "source-map-support": "^0.5.19"
+            }
         },
         "tsutils": {
             "version": "3.21.0",
@@ -23028,7 +23550,7 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "punycode": "^2.1.0"
             }
@@ -23046,7 +23568,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
+            "devOptional": true
         },
         "uuid": {
             "version": "3.4.0",
@@ -23381,7 +23903,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "devOptional": true
         },
         "write-file-atomic": {
             "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@msamblanet/node-config-types",
-    "version": "0.3.2",
+    "version": "0.4.0",
     "private": false,
     "description": "TS types and utility methods for @msamblanet packages",
     "homepage": "https://github.com/msamblanet/node-config-types",
@@ -21,29 +21,29 @@
         "dist"
     ],
     "scripts": {
-      "dev": "node --loader ts-node/esm src/main.ts",
-      "debug": "node --inspect --loader ts-node/esm src/main.ts",
-      "nodemon": "nodemon src/main.ts",
-      "prod:init": "npm ci --only=production",
-      "prod:start": "node dist/main.js",
-      "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-      "test:open": "opener \"./coverage/lcov-report/index.html\"",
-      "test:debug": "node --inspect --experimental-vm-modules node_modules/jest/bin/jest.js",
-      "test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js -- watch",
-      "lint": "xo",
-      "lint:fix": "xo --fix",
-      "build": "npm run build:clean && npm run build:gen",
-      "build:clean": "del-cli dist",
-      "build:check": "tsc --noEmit",
-      "build:gen": "tsc",
-      "prepack": "npm run lint && npm run build:check && npm run build",
-      "lib:check": "ncu",
-      "lib:update:patch": "ncu -u -t patch && npm install",
-      "lib:update:minor": "ncu -u -t minor && npm install",
-      "lib:update:latest": "ncu -u -t latest && npm install",
-      "lib:update:doctor": "ncu --doctor -u -t latest",
-      "lib:unused": "npx depcheck",
-      "applyProjectTemplate": "applyProjectTemplate"
+        "dev": "node --loader ts-node/esm src/main.ts",
+        "debug": "node --inspect --loader ts-node/esm src/main.ts",
+        "nodemon": "nodemon src/main.ts",
+        "prod:init": "npm ci --only=production",
+        "prod:start": "node dist/main.js",
+        "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+        "test:open": "opener \"./coverage/lcov-report/index.html\"",
+        "test:debug": "node --inspect --experimental-vm-modules node_modules/jest/bin/jest.js",
+        "test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js -- watch",
+        "lint": "xo",
+        "lint:fix": "xo --fix",
+        "build": "npm run build:clean && npm run build:gen",
+        "build:clean": "del-cli dist",
+        "build:check": "tsc --noEmit",
+        "build:gen": "tsc",
+        "prepack": "npm run lint && npm run build:check && npm run build",
+        "lib:check": "ncu",
+        "lib:update:patch": "ncu -u -t patch && npm install",
+        "lib:update:minor": "ncu -u -t minor && npm install",
+        "lib:update:latest": "ncu -u -t latest && npm install",
+        "lib:update:doctor": "ncu --doctor -u -t latest",
+        "lib:unused": "npx depcheck",
+        "applyProjectTemplate": "applyProjectTemplate"
     },
     "nodemonConfig": {
         "execMap": {
@@ -121,9 +121,13 @@
     "devDependencies": {
         "@msamblanet/node-project-template": "^0.7.0",
         "@types/extend": "^3.0.1",
+        "jest-mock-extended": "^2.0.4",
         "tsdef": "^0.0.14"
     },
     "engines": {
         "node": ">=16.7.0"
+    },
+    "optionalDependencies": {
+        "@msamblanet/node-slf": "^0.1.2"
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,67 @@
+import { EventEmitter } from 'node:events';
 import extend from 'extend';
 import type { DeepPartial } from 'tsdef'; // Do not use type-fest PartialDeep as it causes validation challenges if the type has unknowns
+import type { ILogAdapter } from '@msamblanet/node-slf';
 
 export type IConfig = {}; // eslint-disable-line @typescript-eslint/ban-types
 export type Override<X> = undefined | null | DeepPartial<X>;
 export type Overrides<X> = Array<Override<X>>;
-export abstract class BaseConfigurable<X extends IConfig> {
+
+export function mergeOptions<Y>(defaults: Override<Y>, ...overrides: Overrides<Y>): Y {
+  return extend(true, {}, defaults, ...overrides) as Y;
+}
+
+export abstract class BaseConfigurable<X extends IConfig = IConfig> {
+  /**
+   * @deprecated Since version 0.4.0 - use the stand-alone function instead
+   */
   public static mergeOptions<Y>(defaults: Override<Y>, ...overrides: Overrides<Y>): Y {
-    return extend(true, {}, defaults, ...overrides) as Y;
+    return mergeOptions(defaults, ...overrides);
   }
 
-  protected config: X;
+  protected readonly config: X;
 
   protected constructor(defaults: X, ...overrides: Overrides<X>) {
-    this.config = BaseConfigurable.mergeOptions<X>(defaults, ...overrides);
+    this.config = mergeOptions<X>(defaults, ...overrides);
   }
 }
-export default BaseConfigurable;
+
+export abstract class BaseEmittingConfigurable<X = IConfig> extends EventEmitter {
+  protected readonly config: X;
+
+  protected constructor(defaults: X, ...overrides: Overrides<X>) {
+    super();
+    this.config = mergeOptions<X>(defaults, ...overrides);
+  }
+}
+
+export abstract class BaseLoggingConfigurable<X = IConfig, L = ILogAdapter> {
+  protected readonly config: X;
+  protected readonly log: L;
+
+  protected constructor(log: L, defaults: X, ...overrides: Overrides<X>) {
+    this.log = log;
+    this.config = mergeOptions<X>(defaults, ...overrides);
+  }
+}
+
+export abstract class BaseLoggingEmittingConfigurable<X = IConfig, L = ILogAdapter> extends EventEmitter {
+  protected readonly config: X;
+  protected readonly log: L;
+
+  protected constructor(log: L, defaults: X, ...overrides: Overrides<X>) {
+    super();
+    this.log = log;
+    this.config = mergeOptions<X>(defaults, ...overrides);
+  }
+}
+
+const defaultExports = {
+  mergeOptions,
+  BaseConfigurable,
+  BaseEmittingConfigurable,
+  BaseLoggingConfigurable,
+  BaseLoggingEmittingConfigurable
+};
+
+export default defaultExports;

--- a/test/baseConfig.test.ts
+++ b/test/baseConfig.test.ts
@@ -1,43 +1,84 @@
+import mock from 'jest-mock-extended';
+import type { ILogAdapter } from '@msamblanet/node-slf';
 import LibDefault, * as Lib from '../src/index';
 
 test('Check Exports', () => {
   expect(Lib).not.toBeNull();
-  expect(Lib.BaseConfigurable).not.toBeNull();
+  expect(Lib.mergeOptions).toBeDefined();
+  expect(Lib.BaseConfigurable).toBeDefined();
+  expect(Lib.BaseEmittingConfigurable).toBeDefined();
+  expect(Lib.BaseLoggingConfigurable).toBeDefined();
+  expect(Lib.BaseLoggingEmittingConfigurable).toBeDefined();
 
-  expect(LibDefault).toEqual(Lib.BaseConfigurable);
+  expect(LibDefault).toMatchObject({
+    mergeOptions: Lib.mergeOptions,
+    BaseConfigurable: Lib.BaseConfigurable,
+    BaseEmittingConfigurable: Lib.BaseEmittingConfigurable,
+    BaseLoggingConfigurable: Lib.BaseLoggingConfigurable,
+    BaseLoggingEmittingConfigurable: Lib.BaseLoggingEmittingConfigurable
+  });
 });
 
 test('Verify Config arg patterns', () => {
   interface TestConfig extends Lib.IConfig {
     a: number | string | null | { b?: number; c?: number; d?: number };
   }
-    type TestConfigOverride = Lib.Override<TestConfig>;
+  type TestConfigOverride = Lib.Override<TestConfig>;
 
-    class X extends Lib.BaseConfigurable<TestConfig> {
-      public constructor(...args: TestConfigOverride[]) {
-        super(undefined as unknown as TestConfig, ...args);
-      }
-
-      public getConfig(): TestConfig {
-        return this.config;
-      }
+  class X extends Lib.BaseConfigurable<TestConfig> {
+    public constructor(...args: TestConfigOverride[]) {
+      super(undefined as unknown as TestConfig, ...args);
     }
 
-    expect(new X(null).getConfig()).toMatchObject({});
-    expect(new X(undefined).getConfig()).toMatchObject({});
-    expect(new X({}).getConfig()).toMatchObject({});
+    public getConfig(): TestConfig {
+      return this.config;
+    }
+  }
 
-    expect(new X({ a: 1 }, { a: { b: 2 } }).getConfig()).toMatchObject({ a: { b: 2 } });
-    expect(new X({ a: 1 }, { a: 2 }).getConfig()).toMatchObject({ a: 2 });
-    expect(new X({ a: 1 }, null, undefined).getConfig()).toMatchObject({ a: 1 });
-    expect(new X({ a: 1 }, null, undefined, { a: 2 }).getConfig()).toMatchObject({ a: 2 });
-    expect(new X({ a: 1 }, null, undefined, { a: '' }).getConfig()).toMatchObject({ a: '' });
-    expect(new X({ a: 1 }, null, undefined, { a: null }).getConfig()).toMatchObject({ a: null });
-    expect(new X({ a: 1 }, null, undefined, { a: undefined }).getConfig()).toMatchObject({ a: 1 });
+  expect(new X(null).getConfig()).toMatchObject({});
+  expect(new X(undefined).getConfig()).toMatchObject({});
+  expect(new X({}).getConfig()).toMatchObject({});
 
-    expect(new X({ a: { b: 1, c: 2 } }).getConfig()).toMatchObject({ a: { b: 1, c: 2 } });
-    expect(new X({ a: { b: 1, c: 2 } }, { a: { c: 3, d: 4 } }).getConfig()).toMatchObject({ a: { b: 1, c: 3, d: 4 } });
-    expect(new X({ a: { b: 1, c: 2 } }, { a: 9 }).getConfig()).toMatchObject({ a: 9 });
-    expect(new X({ a: { b: 1, c: 2 } }, { a: null }).getConfig()).toMatchObject({ a: null });
-    expect(new X({ a: { b: 1, c: 2 } }, { a: undefined }).getConfig()).toMatchObject({ a: { b: 1, c: 2 } });
+  expect(new X({ a: 1 }, { a: { b: 2 } }).getConfig()).toMatchObject({ a: { b: 2 } });
+  expect(new X({ a: 1 }, { a: 2 }).getConfig()).toMatchObject({ a: 2 });
+  expect(new X({ a: 1 }, null, undefined).getConfig()).toMatchObject({ a: 1 });
+  expect(new X({ a: 1 }, null, undefined, { a: 2 }).getConfig()).toMatchObject({ a: 2 });
+  expect(new X({ a: 1 }, null, undefined, { a: '' }).getConfig()).toMatchObject({ a: '' });
+  expect(new X({ a: 1 }, null, undefined, { a: null }).getConfig()).toMatchObject({ a: null });
+  expect(new X({ a: 1 }, null, undefined, { a: undefined }).getConfig()).toMatchObject({ a: 1 });
+
+  expect(new X({ a: { b: 1, c: 2 } }).getConfig()).toMatchObject({ a: { b: 1, c: 2 } });
+  expect(new X({ a: { b: 1, c: 2 } }, { a: { c: 3, d: 4 } }).getConfig()).toMatchObject({ a: { b: 1, c: 3, d: 4 } });
+  expect(new X({ a: { b: 1, c: 2 } }, { a: 9 }).getConfig()).toMatchObject({ a: 9 });
+  expect(new X({ a: { b: 1, c: 2 } }, { a: null }).getConfig()).toMatchObject({ a: null });
+  expect(new X({ a: { b: 1, c: 2 } }, { a: undefined }).getConfig()).toMatchObject({ a: { b: 1, c: 2 } });
+});
+
+test('Touch BaseConfigurable.mergeOptions', () => {
+  expect(Lib.BaseConfigurable.mergeOptions<Record<string, number>>({ a: 1, b: 2 }, { b: 3, c: 4 })).toMatchObject({ a: 1, b: 3, c: 4 });
+});
+
+test('Touch all variations', () => {
+  class TestEmittingConfigurable extends Lib.BaseEmittingConfigurable {
+    public constructor() {
+      super({});
+    }
+  }
+  class TestLoggingConfigurable extends Lib.BaseLoggingConfigurable {
+    public constructor() {
+      super(mock.mock<ILogAdapter>(), {});
+    }
+  }
+  class TestLoggingEmittingConfigurable extends Lib.BaseLoggingEmittingConfigurable {
+    public constructor() {
+      super(mock.mock<ILogAdapter>(), {});
+    }
+  }
+
+  // Just touch all of these to make sure they are working...
+  expect(new TestEmittingConfigurable()).toBeDefined();
+  expect(new TestEmittingConfigurable().emit('UNITTEST')).toEqual(false);
+  expect(new TestLoggingConfigurable()).toBeDefined();
+  expect(new TestLoggingEmittingConfigurable()).toBeDefined();
+  expect(new TestLoggingEmittingConfigurable().emit('UNITTEST')).toEqual(false);
 });


### PR DESCRIPTION
- 2021-10-27: v0.4.0
  - Change readme.md example to use proper import
  - Move mergeOptions into stand-alone method
  - Deprecate BaseConfigurable.mergeOptions
  - Add BaseEmittingConfigurable, BaseLoggingConfigurable, BaseLoggingEmittingConfigurable
  - Removed hard requirement to extend IConfig
  - Added default for type of config (IConfig) and the logger (ILogAdpater from @msamblanet/node-slf)